### PR TITLE
B0vols fmaps

### DIFF
--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -137,11 +137,11 @@ class Task(tasks.BaseTask):
 				'--pwd', fmap_dir,
 				self._fsl_sif,
 				'/APPS/fsl/bin/fslselectvols',
-				'-i', 'dwmri.nii.gz',
+				'-i', fmap_basename,
 				'-o', fmap_basename,
 				'--vols=0'
 			]
-			logger.info(f'running {json.dumps(cmd, indent=2)} on {fmap}')
+			#logger.info(f'running {json.dumps(cmd, indent=2)} on {fmap}')
 
 			cmdline = subprocess.list2cmdline(cmd)
 			logger.info(f'running {cmdline}')
@@ -151,7 +151,7 @@ class Task(tasks.BaseTask):
 				logger.critical(f'fslselectvols command failed')
 				raise subprocess.CalledProcessError(returncode=proc.returncode, cmd=cmdline)
 
-			print(fmap_dir + basename)
+			print(fmap_dir + fmap_basename)
 
 			truncated_fmaps.append(fmap_dir + fmap_basename)
 

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -120,7 +120,7 @@ class Task(tasks.BaseTask):
 	# this method serves to create the accompanying spec file for prequal 
 	# the contents of the file depends on the SeriesDescription stored in the metadata
 
-	def trucate_fmaps(self, fmap_files):
+	def truncate_fmaps(self, fmap_files):
 		"""
 		method that will extract all the b0 volumes from the scans designated as BIDS fieldmaps
 		"""

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -71,7 +71,7 @@ class Task(tasks.BaseTask):
 
 		# truncate down the fmap files to include just b0 volumes
 
-		truncated_fmaps = trucate_fmaps(self, fmap_files)
+		truncated_fmaps = truncate_fmaps(self, fmap_files)
 
 		# get the basename of the file and then remove the extension
 		for fmap in truncated_fmaps:

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -124,7 +124,7 @@ class Task(tasks.BaseTask):
 		"""
 		method that will extract all the b0 volumes from the scans designated as BIDS fieldmaps
 		"""
-		get_fsl_sif(self)
+		get_fsl_sif()
 
 		for fmap in fmap_files:
 			print(fmap)

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -71,7 +71,7 @@ class Task(tasks.BaseTask):
 
 		# truncate down the fmap files to include just b0 volumes
 
-		truncated_fmaps = truncate_fmaps(fmap_files)
+		truncated_fmaps = self.truncate_fmaps(fmap_files)
 
 		# get the basename of the file and then remove the extension
 		for fmap in truncated_fmaps:
@@ -124,21 +124,23 @@ class Task(tasks.BaseTask):
 		"""
 		method that will extract all the b0 volumes from the scans designated as BIDS fieldmaps
 		"""
-		get_fsl_sif()
+		self.get_fsl_sif()
 
 		for fmap in fmap_files:
-			print(fmap)
-			sys.exit()
+			fmap_basename = os.path.basename(fmap)
+			fmap_dir = os.path.dirname(fmap)
+			print(fmap_dir)
 			cmd = [
 				'singularity',
 				'exec',
-				'--pwd', preproc_dir,
+				'--pwd', fmap_dir,
 				self._fsl_sif,
 				'/APPS/fsl/bin/fslselectvols',
 				'-i', 'dwmri.nii.gz',
-				'-o', 'b0_volume',
+				'-o', fmap_basename,
 				'--vols=0'
 			]
+			logger.info(f'running {json.dumps(cmd, indent=2)} on {fmap}')
 
 
 	def get_fsl_sif(self):

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -154,8 +154,8 @@ class Task(tasks.BaseTask):
 			truncated_fmaps.append(fmap_dir + f'/{fmap_basename}')
 
 
-		print(truncated_fmaps)
 		sys.exit()
+		return truncated_fmaps
 
 
 	def get_fsl_sif(self):

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -71,7 +71,7 @@ class Task(tasks.BaseTask):
 
 		# truncate down the fmap files to include just b0 volumes
 
-		truncated_fmaps = truncate_fmaps(self, fmap_files)
+		truncated_fmaps = truncate_fmaps(fmap_files)
 
 		# get the basename of the file and then remove the extension
 		for fmap in truncated_fmaps:

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -151,9 +151,7 @@ class Task(tasks.BaseTask):
 				logger.critical(f'fslselectvols command failed')
 				raise subprocess.CalledProcessError(returncode=proc.returncode, cmd=cmdline)
 
-			print(fmap_dir + fmap_basename)
-
-			truncated_fmaps.append(fmap_dir + fmap_basename)
+			truncated_fmaps.append(fmap_dir + f'/fmap_basename')
 
 
 		print(truncated_fmaps)

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -126,10 +126,11 @@ class Task(tasks.BaseTask):
 		"""
 		self.get_fsl_sif()
 
+		truncated_fmaps = []
+
 		for fmap in fmap_files:
 			fmap_basename = os.path.basename(fmap)
 			fmap_dir = os.path.dirname(fmap)
-			print(fmap_dir)
 			cmd = [
 				'singularity',
 				'exec',
@@ -141,6 +142,22 @@ class Task(tasks.BaseTask):
 				'--vols=0'
 			]
 			logger.info(f'running {json.dumps(cmd, indent=2)} on {fmap}')
+
+			cmdline = subprocess.list2cmdline(cmd)
+			logger.info(f'running {cmdline}')
+			proc = subprocess.Popen(cmdline, shell=True, stdout=subprocess.PIPE)
+			proc.communicate()
+			if proc.returncode > 0:
+				logger.critical(f'fslselectvols command failed')
+				raise subprocess.CalledProcessError(returncode=proc.returncode, cmd=cmdline)
+
+			print(fmap_dir + basename)
+
+			truncated_fmaps.append(fmap_dir + fmap_basename)
+
+
+		print(truncated_fmaps)
+		sys.exit()
 
 
 	def get_fsl_sif(self):

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -151,7 +151,7 @@ class Task(tasks.BaseTask):
 				logger.critical(f'fslselectvols command failed')
 				raise subprocess.CalledProcessError(returncode=proc.returncode, cmd=cmdline)
 
-			truncated_fmaps.append(fmap_dir + f'/fmap_basename')
+			truncated_fmaps.append(fmap_dir + f'/{fmap_basename}')
 
 
 		print(truncated_fmaps)

--- a/dwiqc/tasks/prequal.py
+++ b/dwiqc/tasks/prequal.py
@@ -154,7 +154,6 @@ class Task(tasks.BaseTask):
 			truncated_fmaps.append(fmap_dir + f'/{fmap_basename}')
 
 
-		sys.exit()
 		return truncated_fmaps
 
 


### PR DESCRIPTION
New code added to the prequal.py task that will now create new fmap files by extracting all b0 volumes and creating new fmap files with only those b0 volumes included. This should help with issues of prenormalization when non b0 volumes are included in fmap files.