### PR TITLE
Multiple t1w

### DIFF
--- a/dwiqc/cli/get.py
+++ b/dwiqc/cli/get.py
@@ -1,6 +1,7 @@
 import os
 import re
 import sys
+import pdb
 import json
 import yaml
 import yaxil
@@ -45,20 +46,7 @@ def do(args):
     scan_labels = get_scans(conf) ### get a list of the scan types/labels
 
     # query dwi and T1w scans from XNAT
-    with yaxil.session(auth) as ses:
-        scans = col.defaultdict(dict)
-        for scan in ses.scans(label=args.label, project=args.project):
-            note = scan['note']
-            for scan_label in scan_labels:
-                is_match = match(note, conf['dwiqc'][scan_label]['tag'])
-                if is_match:
-                    run = is_match.group('run')
-                    run = re.sub('[^0-9]', '', run or '1') # get rid of any character that is not a digit between 0-9 and if run is None, make it 1.
-                    scans[run][scan_label] = scan['id']
-
-    logger.info('downloading the following scans:')
-    logger.info(json.dumps(scans, indent=2))
-
+    scans_to_download = parse_scan_notes(scan_labels, conf, auth, args.label, args.project)
 
     # iterate over the scans dictionary, search for the scans with the correct note/tag
 
@@ -68,8 +56,108 @@ def do(args):
                 logger.info('getting run=%s, scan=%s', run, scansr[scan_label])
                 download_scan(args, auth, run, scansr[scan_label], scan_label, conf, verbose=args.verbose)
 
-def run_xnattagger(args):
+def parse_scan_notes(scan_labels, conf, auth, label, project):
+    """
+    Iterate through all scans of the given session
+    Check for matches in the user provided config file
+    If there is more than one T1w image found, do additional
+    processing
+    """
+    anat_tags = {}
+    with yaxil.session(auth) as ses:
+        scans = col.defaultdict(dict)
+        for scan in ses.scans(label=label, project=project):
+            note = scan['note']
+            for scan_label in scan_labels:
+                is_match = match(note, conf['dwiqc'][scan_label]['tag'])
+                if is_match:
+                    run = is_match.group('run')
+                    run = re.sub('[^0-9]', '', run or '1') # get rid of any character that is not a digit between 0-9 and if run is None, make it 1.
+                    scans[run][scan_label] = scan['id']
+                    if scan_label.lower() == 't1w':
+                        anat_tags[scan['ID']] = note
+    if count_t1w(scans) > 1:
+        winning_t1w = determine_t1w(anat_tags)
+    if winning_t1w:
+        scans = assign_winning_t1w(scans, winning_t1w)
+    else:
+        logger.warning('Unable to determine which t1w image to use. See <documentation link> for more details.')
+        logger.warning('Continuing pipeline without t1w image. Pipeline quality may be affected or crash altogether.')
+    pdb.set_trace()
+    logger.info('downloading the following scans:')
+    logger.info(json.dumps(scans, indent=2))
 
+
+def assign_winning_t1w(scans, winning_t1w):
+    """
+    Remove all non-winning t1w entries from scans, delete any run that is
+    left with only a 't1w' entry, then insert the winning t1w scan ID into
+    every run that contains a 'dwi_main' key.
+    """
+    # Strip out any t1w entry that isn't the winner
+    for run_num in list(scans.keys()):
+        if 't1w' in scans[run_num] and scans[run_num]['t1w'] != winning_t1w:
+            logger.info(f'Removing non-winning t1w from run {run_num}')
+            del scans[run_num]['t1w']
+
+    # Delete any run that only contains a t1w entry
+    for run_num in list(scans.keys()):
+        if list(scans[run_num].keys()) == ['t1w']:
+            logger.info(f'Deleting run {run_num} as it only contains a t1w entry')
+            del scans[run_num]
+        elif not list(scans[run_num].keys()):
+            logger.info(f'Deleting run {run_num} as it is empty')
+            del scans[run_num]
+
+    # Pair the winning t1w with every run that has a dwi_main
+    for run_num in scans.keys():
+        if 'dwi_main' in scans[run_num]:
+            logger.info(f'Assigning winning t1w {winning_t1w} to run {run_num}')
+            scans[run_num]['t1w'] = winning_t1w
+
+    return scans
+
+
+def count_t1w(scans):
+    '''
+    Count the number of t1w images found in session
+    '''
+    num_t1w = 0
+    for _, inner_dict in scans.items():
+        if isinstance(inner_dict, dict) and 't1w' in inner_dict:
+            num_t1w += 1
+    return num_t1w
+
+
+def determine_t1w(anat_tags):
+    '''
+    Try to determine which T1w image to use if more
+    than one is supplied. It will take the following
+    steps serially.
+    1. Look for the #t1w_dwiqc tag uniquely exists. If
+    so, use that image.
+    2. Check if any of the T1w images have been 
+    set to "unusable" in XNAT. If a remaining one is usable,
+    use that T1w image.
+    3. Use Otsu thresholding to run a rough SNR calculation
+    on each T1 and use the one with the higher SNR
+    '''
+    winning_scan = check_t1w_tag(anat_tags)
+    if winning_scan:
+        return winning_scan
+
+
+
+def check_t1w_tag(anat_tags):
+    t1_scan_num = [key for key, value in anat_tags.items() if value.lower() == '#t1w_001'][0] # DONT FORGET TO CHANGE BACK TO #t1w_dwiqc !!!!!!!!
+    if t1_scan_num:
+        logger.info('Found T1w image with #t1w_dwiqc tag, discarding others')    
+        return t1_scan_num
+    else:
+        logger.info('No T1w image note contains #t1w_dwiqc (case insensitive), checking for XNAT usability.')
+        return
+
+def run_xnattagger(args):
     """
     This function will run xnattagger with the supplied (or default) config file
 

--- a/dwiqc/cli/get.py
+++ b/dwiqc/cli/get.py
@@ -50,7 +50,7 @@ def do(args):
 
     # iterate over the scans dictionary, search for the scans with the correct note/tag
 
-    for run,scansr in scans.items():
+    for run,scansr in scans_to_download.items():
         for scan_label in scan_labels:
             if scan_label in scansr:
                 logger.info('getting run=%s, scan=%s', run, scansr[scan_label])
@@ -78,14 +78,15 @@ def parse_scan_notes(scan_labels, conf, auth, label, project):
                         anat_tags[scan['ID']] = note
     if count_t1w(scans) > 1:
         winning_t1w = determine_t1w(anat_tags)
-    if winning_t1w:
-        scans = assign_winning_t1w(scans, winning_t1w)
-    else:
-        logger.warning('Unable to determine which t1w image to use. See <documentation link> for more details.')
-        logger.warning('Continuing pipeline without t1w image. Pipeline quality may be affected or crash altogether.')
+        if winning_t1w:
+            scans = assign_winning_t1w(scans, winning_t1w)
+        else:
+            logger.warning('Unable to determine which t1w image to use. See <documentation link> for more details.')
+            logger.warning('Continuing pipeline without t1w image. Pipeline quality may be affected or crash altogether.')
     pdb.set_trace()
     logger.info('downloading the following scans:')
     logger.info(json.dumps(scans, indent=2))
+    return scans
 
 
 def assign_winning_t1w(scans, winning_t1w):

--- a/dwiqc/cli/get.py
+++ b/dwiqc/cli/get.py
@@ -49,6 +49,9 @@ def do(args):
 
     scan_labels = get_scan_types(conf)
 
+    logger.info('downloading the following scans:')
+    logger.info(json.dumps(scans_to_download, indent=2))
+
     # download scans
 
     for run,scansr in scans_to_download.items():
@@ -159,7 +162,7 @@ def get_usable_scans(auth, label, project):
             all_scans = []
             for scan in ses.scans(label=label, project=project):
                 if scan['quality'] == 'unusable':
-                    logger.warning(f'scan {scan['ID']} is unusable and will not be downloaded')
+                    logger.warning(f"scan {scan['ID']} is unusable and will not be downloaded")
                     continue
                 else:
                     all_scans.append(scan)
@@ -174,6 +177,10 @@ def run_xnattagger(args):
 
     with open(args.tagger_config) as fo:
         filters = yaml.load(fo, Loader=yaml.SafeLoader)['xnat-tagger']
+
+    tagger_dwi = Tagger(args.xnat_alias, filters, 'dwi', args.label, append_tag_digits=True)
+    tagger_dwi.generate_updates()
+    tagger_dwi.apply_updates()
 
     tagger = Tagger(args.xnat_alias, filters, 't1w', args.label, append_tag_digits=False)
     tagger.generate_updates()

--- a/dwiqc/cli/get.py
+++ b/dwiqc/cli/get.py
@@ -6,7 +6,6 @@ import json
 import yaml
 import yaxil
 import logging
-import argparse as ap
 import subprocess as sp
 import collections as col
 from xnattagger import Tagger
@@ -48,7 +47,9 @@ def do(args):
     # query dwi and T1w scans from XNAT
     scans_to_download = find_scans_to_download(scan_labels, conf, auth, args.label, args.project)
 
-    # iterate over the scans dictionary, search for the scans with the correct note/tag
+    scan_labels = get_scan_types(conf)
+
+    # download scans
 
     for run,scansr in scans_to_download.items():
         for scan_label in scan_labels:
@@ -73,7 +74,7 @@ def find_scans_to_download(scan_labels, conf, auth, label, project):
 
     keeper_scans = populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num_diffusion_scans=len(keeper_scans))
 
-
+    return keeper_scans
 
 
 def find_main_diffusion_scans(keeper_scans, all_usable_scans, conf):
@@ -118,6 +119,8 @@ def populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num
             if contains_just_dwiqc_t1w(scan['note']):
                 for run in keeper_scans:
                     keeper_scans[run]['t1w'] = scan['ID']
+                scan_labels.remove('t1w')
+                break
             else:
                 run = is_match.group('run').lstrip('_')
                 if run not in keeper_scans:
@@ -125,32 +128,24 @@ def populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num
                     sys.exit()
                 keeper_scans[run]['t1w'] = scan['id']
 
-    
+    # populate fmap scans
+    for scan in all_usable_scans:
+        for scan_label in scan_labels:
+            is_match = match(scan['note'], conf['dwiqc'][scan_label]['tag'])
+            if is_match:
+                run = is_match.group('run').lstrip('_')
+                keeper_scans[run][scan_label] = scan['id']
+
+    return keeper_scans
 
 def contains_just_dwiqc_t1w(scan_note):
-    """
+    '''
     Check if '#DWIQC_T1w' exists as a standalone tag in the given scan note.
     Returns False if followed by additional characters (e.g. '_001').
     Case insensitive.
-    """
+    '''
     pattern = r'(?i)#DWIQC_T1w(?!\w)'
     return bool(re.search(pattern, scan_note))
-
-    '''
-
-    # check if there is more than one t1w image, determine which one to use if so                    
-    if count_t1w(scans) > 1:
-        winning_t1w = determine_t1w(anat_tags, scans)
-        if winning_t1w:
-            scans = assign_winning_t1w(scans, winning_t1w)
-        else:
-            logger.warning('Unable to determine which t1w image to use. See <documentation link> for more details.')
-            logger.warning('Continuing pipeline without t1w image. Pipeline quality may be affected or crash altogether.')
-    logger.info('downloading the following scans:')
-    logger.info(json.dumps(scans, indent=2))
-    return scans
-    '''
-
 
 def verify_dwi_label(conf):
     try:
@@ -158,69 +153,6 @@ def verify_dwi_label(conf):
     except:
         logger.error('please specify a "dwi_main" label in your download-config.yaml file')
         sys.exit()
-
-def assign_winning_t1w(scans, winning_t1w):
-    """
-    Remove all non-winning t1w entries from scans, delete any run that is
-    left with only a 't1w' entry, then insert the winning t1w scan ID into
-    every run that contains a 'dwi_main' key.
-    """
-    # Strip out any t1w entry that isn't the winner
-    for run_num in list(scans.keys()):
-        if 't1w' in scans[run_num] and scans[run_num]['t1w'] != winning_t1w:
-            logger.info(f'Removing non-winning t1w from run {run_num}')
-            del scans[run_num]['t1w']
-
-    # Delete any run that only contains a t1w entry
-    for run_num in list(scans.keys()):
-        if list(scans[run_num].keys()) == ['t1w']:
-            logger.info(f'Deleting run {run_num} as it only contains a t1w entry')
-            del scans[run_num]
-        elif not list(scans[run_num].keys()):
-            logger.info(f'Deleting run {run_num} as it is empty')
-            del scans[run_num]
-
-    # Pair the winning t1w with every run that has a dwi_main
-    for run_num in scans.keys():
-        if 'dwi_main' in scans[run_num]:
-            logger.info(f'Assigning winning t1w {winning_t1w} to run {run_num}')
-            scans[run_num]['t1w'] = winning_t1w
-
-    return scans
-
-
-def count_t1w(scans):
-    '''
-    Count the number of t1w images found in session
-    '''
-    num_t1w = 0
-    for _, inner_dict in scans.items():
-        if isinstance(inner_dict, dict) and 't1w' in inner_dict:
-            num_t1w += 1
-    return num_t1w
-
-
-def determine_t1w(anat_tags, scans):
-    '''
-    Try to determine which T1w image to use if more
-    than one is supplied. It will take the following
-    steps serially.
-    1. Look for the #t1w_dwiqc tag uniquely exists. If
-    so, use that image.
-    2. Check if any of the T1w images have been 
-    set to "unusable" in XNAT. If a remaining one is usable,
-    use that T1w image.
-    '''
-
-    # Look for winning scan with first method
-    winning_scan = check_t1w_tag(anat_tags)
-    if winning_scan:
-        return winning_scan
-
-    # Look for winning scan with second method
-    winning_scan = check_t1w_xnat_usability(anat_tags)
-    if winning_scan:
-        return winning_scan
 
 def get_usable_scans(auth, label, project):
     with yaxil.session(auth) as ses:
@@ -233,24 +165,10 @@ def get_usable_scans(auth, label, project):
                     all_scans.append(scan)
     return all_scans
 
-def check_t1w_tag(anat_tags):
-    try:
-        t1_scan_num = [key for key, value in anat_tags.items() if value.lower() == '#dwiqc_t1w'][0]
-    except IndexError:
-        logger.info('No T1w image note contains #t1w_dwiqc (case insensitive), checking for XNAT usability.')
-        return
-    if t1_scan_num:
-        logger.info('Found T1w image with #t1w_dwiqc tag, discarding others')    
-        return t1_scan_num
-    else:
-        logger.info('No T1w image note contains #t1w_dwiqc (case insensitive), checking for XNAT usability.')
-        return
-
 def run_xnattagger(args):
-    """
+    '''
     This function will run xnattagger with the supplied (or default) config file
-
-    """
+    '''
 
     logging.info('Running xnattagger...')
 
@@ -262,22 +180,18 @@ def run_xnattagger(args):
     tagger.apply_updates()
 
 def get_scan_types(conf):
-
-    """
+    '''
     Helper function to dynamically create a list of all the modalities/scans listed in the config file
-    
-    """
+    '''
     
     scan_types = [scan_type for scan_type in conf['dwiqc']]
 
     return scan_types
 
 def download_scan(args, auth, run, scan, config_label, input_config, verbose=False):
-
-    """
+    '''
     Function that downloads an individual scan based on information from the config input file and command line arguments.
-   
-    """
+    '''
 
     # check for bids sub-directory specification in config file
     try:
@@ -362,11 +276,10 @@ def download_scan(args, auth, run, scan, config_label, input_config, verbose=Fal
         sp.check_output(cmd, input=config.encode('utf-8'))
 
 def match(note, patterns):
-
-    """
+    '''
     This function uses regular expression matching to match the tags in the scan note field to the config file
+    '''
 
-    """
     for pattern in patterns:
         m = re.match(pattern, note, flags=re.IGNORECASE)
         if m:

--- a/dwiqc/cli/get.py
+++ b/dwiqc/cli/get.py
@@ -43,10 +43,10 @@ def do(args):
 
     conf = yaml.safe_load(open(args.download_config)) # load yaml config file
 
-    scan_labels = get_scans(conf) ### get a list of the scan types/labels
+    scan_labels = get_scan_types(conf) ### get a list of the scan types/labels
 
     # query dwi and T1w scans from XNAT
-    scans_to_download = parse_scan_notes(scan_labels, conf, auth, args.label, args.project)
+    scans_to_download = find_scans_to_download(scan_labels, conf, auth, args.label, args.project)
 
     # iterate over the scans dictionary, search for the scans with the correct note/tag
 
@@ -56,38 +56,108 @@ def do(args):
                 logger.info('getting run=%s, scan=%s', run, scansr[scan_label])
                 download_scan(args, auth, run, scansr[scan_label], scan_label, conf, verbose=args.verbose)
 
-def parse_scan_notes(scan_labels, conf, auth, label, project):
+def find_scans_to_download(scan_labels, conf, auth, label, project):
     """
     Iterate through all scans of the given session
     Check for matches in the user provided config file
     If there is more than one T1w image found, do additional
     processing
     """
-    anat_tags = {}
-    with yaxil.session(auth) as ses:
-        scans = col.defaultdict(dict)
-        for scan in ses.scans(label=label, project=project):
-            note = scan['note']
-            for scan_label in scan_labels:
-                is_match = match(note, conf['dwiqc'][scan_label]['tag'])
-                if is_match:
-                    run = is_match.group('run')
-                    run = re.sub('[^0-9]', '', run or '1') # get rid of any character that is not a digit between 0-9 and if run is None, make it 1.
-                    scans[run][scan_label] = scan['id']
-                    if scan_label.lower() == 't1w':
-                        anat_tags[scan['ID']] = note
+    all_usable_scans = get_usable_scans(auth, label, project)
+    keeper_scans = col.defaultdict(dict)
+    
+    keeper_scans, remove_dwi_main_label = find_main_diffusion_scans(keeper_scans, all_usable_scans, conf)
+
+    if remove_dwi_main_label:
+        scan_labels.remove('dwi_main')
+
+    keeper_scans = populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num_diffusion_scans=len(keeper_scans))
+
+
+
+
+def find_main_diffusion_scans(keeper_scans, all_usable_scans, conf):
+    '''
+    find all the diffusion scans in the session
+    '''
+    for scan in all_usable_scans:
+        verify_dwi_label(conf)
+        is_match = match(scan['note'], conf['dwiqc']['dwi_main']['tag'])
+        if is_match:
+            run = is_match.group('run').lstrip('_')
+            keeper_scans[run]['dwi_main'] = scan['id']
+
+    if not diffusion_exist(keeper_scans):
+        logger.error('No diffusion scans found. Please check your tagging convention and your download-config.yaml file.')
+        sys.exit()
+
+    else:
+        logger.debug('marking dwi_main scan label as complete')
+        return keeper_scans, True
+
+
+def diffusion_exist(keeper_scans):
+    for value in keeper_scans.values():
+        if 'dwi_main' in value:
+            return True
+    return False
+
+
+def populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num_diffusion_scans):
+    '''
+    Populate the keeper_scans data structure by finding t1w images first and checking their 
+    note field.
+    If #DWIQC_T1w tag is found, that t1 is added to all diffusion scan runs. Otherwise, it 
+    is based on the run number.
+    '''
+
+    # populate t1w scans first
+    for scan in all_usable_scans:
+        is_match = match(scan['note'], conf['dwiqc']['t1w']['tag'])
+        if is_match:
+            if contains_just_dwiqc_t1w(scan['note']):
+                for run in keeper_scans:
+                    keeper_scans[run]['t1w'] = scan['ID']
+            else:
+                run = is_match.group('run').lstrip('_')
+                if run not in keeper_scans:
+                    logger.error('More than one t1w image found. Please specify desired t1 image with tag: #DWIQC_T1w (note the lack of trailing integers).\nSee documentation for further details: <docs_link>')
+                    sys.exit()
+                keeper_scans[run]['t1w'] = scan['id']
+
+    
+
+def contains_just_dwiqc_t1w(scan_note):
+    """
+    Check if '#DWIQC_T1w' exists as a standalone tag in the given scan note.
+    Returns False if followed by additional characters (e.g. '_001').
+    Case insensitive.
+    """
+    pattern = r'(?i)#DWIQC_T1w(?!\w)'
+    return bool(re.search(pattern, scan_note))
+
+    '''
+
+    # check if there is more than one t1w image, determine which one to use if so                    
     if count_t1w(scans) > 1:
-        winning_t1w = determine_t1w(anat_tags)
+        winning_t1w = determine_t1w(anat_tags, scans)
         if winning_t1w:
             scans = assign_winning_t1w(scans, winning_t1w)
         else:
             logger.warning('Unable to determine which t1w image to use. See <documentation link> for more details.')
             logger.warning('Continuing pipeline without t1w image. Pipeline quality may be affected or crash altogether.')
-    pdb.set_trace()
     logger.info('downloading the following scans:')
     logger.info(json.dumps(scans, indent=2))
     return scans
+    '''
 
+
+def verify_dwi_label(conf):
+    try:
+        dwi_label = conf['dwiqc']['dwi_main']['tag']
+    except:
+        logger.error('please specify a "dwi_main" label in your download-config.yaml file')
+        sys.exit()
 
 def assign_winning_t1w(scans, winning_t1w):
     """
@@ -130,7 +200,7 @@ def count_t1w(scans):
     return num_t1w
 
 
-def determine_t1w(anat_tags):
+def determine_t1w(anat_tags, scans):
     '''
     Try to determine which T1w image to use if more
     than one is supplied. It will take the following
@@ -140,17 +210,35 @@ def determine_t1w(anat_tags):
     2. Check if any of the T1w images have been 
     set to "unusable" in XNAT. If a remaining one is usable,
     use that T1w image.
-    3. Use Otsu thresholding to run a rough SNR calculation
-    on each T1 and use the one with the higher SNR
     '''
+
+    # Look for winning scan with first method
     winning_scan = check_t1w_tag(anat_tags)
     if winning_scan:
         return winning_scan
 
+    # Look for winning scan with second method
+    winning_scan = check_t1w_xnat_usability(anat_tags)
+    if winning_scan:
+        return winning_scan
 
+def get_usable_scans(auth, label, project):
+    with yaxil.session(auth) as ses:
+            all_scans = []
+            for scan in ses.scans(label=label, project=project):
+                if scan['quality'] == 'unusable':
+                    logger.warning(f'scan {scan['ID']} is unusable and will not be downloaded')
+                    continue
+                else:
+                    all_scans.append(scan)
+    return all_scans
 
 def check_t1w_tag(anat_tags):
-    t1_scan_num = [key for key, value in anat_tags.items() if value.lower() == '#t1w_001'][0] # DONT FORGET TO CHANGE BACK TO #t1w_dwiqc !!!!!!!!
+    try:
+        t1_scan_num = [key for key, value in anat_tags.items() if value.lower() == '#dwiqc_t1w'][0]
+    except IndexError:
+        logger.info('No T1w image note contains #t1w_dwiqc (case insensitive), checking for XNAT usability.')
+        return
     if t1_scan_num:
         logger.info('Found T1w image with #t1w_dwiqc tag, discarding others')    
         return t1_scan_num
@@ -167,13 +255,13 @@ def run_xnattagger(args):
     logging.info('Running xnattagger...')
 
     with open(args.tagger_config) as fo:
-        filters = yaml.load(fo, Loader=yaml.SafeLoader)
+        filters = yaml.load(fo, Loader=yaml.SafeLoader)['xnat-tagger']
 
-    tagger = Tagger(args.xnat_alias, filters, 'dwi', args.label)
+    tagger = Tagger(args.xnat_alias, filters, 't1w', args.label, append_tag_digits=False)
     tagger.generate_updates()
     tagger.apply_updates()
 
-def get_scans(conf):
+def get_scan_types(conf):
 
     """
     Helper function to dynamically create a list of all the modalities/scans listed in the config file

--- a/dwiqc/cli/tandem.py
+++ b/dwiqc/cli/tandem.py
@@ -47,29 +47,21 @@ def do(args):
 
     conf = yaml.safe_load(open(args.download_config)) # load yaml config file
 
-    scan_labels = get_scans(conf) ### get a list of the scan types/labels
+    scan_labels = get_scan_types(conf) ### get a list of the scan types/labels
 
     # query dwi and T1w scans from XNAT
-    with yaxil.session(auth) as ses:
-        scans = col.defaultdict(dict)
-        for scan in ses.scans(label=args.label, project=args.project):
-            note = scan['note']
-            for scan_label in scan_labels:
-                is_match = match(note, conf['dwiqc'][scan_label]['tag'])
-                if is_match:
-                    run = is_match.group('run')
-                    run = re.sub('[^0-9]', '', run or '1') # get rid of any character that is not a digit between 0-9 and if run is None, make it 1.
-                    scans[run][scan_label] = scan['id']
+    scans_to_download = find_scans_to_download(scan_labels, conf, auth, args.label, args.project)
 
     logger.info('downloading the following scans:')
     logger.info(json.dumps(scans, indent=2))
 
     subject_label = scan['subject_label']
 
+    scan_labels = get_scan_types(conf)
 
     # iterate over the scans dictionary, search for the scans with the correct note/tag
 
-    for run,scansr in scans.items():
+    for run,scansr in scans_to_download.items():
         for scan_label in scan_labels:
             if scan_label in scansr:
                 logger.info('getting run=%s, scan=%s', run, scansr[scan_label])
@@ -84,6 +76,100 @@ def do(args):
     logger.debug('sub=%s, ses=%s', args.sub, args.ses)
     process.do(args)
 
+def find_scans_to_download(scan_labels, conf, auth, label, project):
+    """
+    Iterate through all scans of the given session
+    Check for matches in the user provided config file
+    If there is more than one T1w image found, do additional
+    processing
+    """
+    all_usable_scans = get_usable_scans(auth, label, project)
+    keeper_scans = col.defaultdict(dict)
+    
+    keeper_scans, remove_dwi_main_label = find_main_diffusion_scans(keeper_scans, all_usable_scans, conf)
+
+    if remove_dwi_main_label:
+        scan_labels.remove('dwi_main')
+
+    keeper_scans = populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num_diffusion_scans=len(keeper_scans))
+
+    return keeper_scans
+
+def populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num_diffusion_scans):
+    '''
+    Populate the keeper_scans data structure by finding t1w images first and checking their 
+    note field.
+    If #DWIQC_T1w tag is found, that t1 is added to all diffusion scan runs. Otherwise, it 
+    is based on the run number.
+    '''
+
+    # populate t1w scans first
+    for scan in all_usable_scans:
+        is_match = match(scan['note'], conf['dwiqc']['t1w']['tag'])
+        if is_match:
+            if contains_just_dwiqc_t1w(scan['note']):
+                for run in keeper_scans:
+                    keeper_scans[run]['t1w'] = scan['ID']
+                scan_labels.remove('t1w')
+                break
+            else:
+                run = is_match.group('run').lstrip('_')
+                if run not in keeper_scans:
+                    logger.error('More than one t1w image found. Please specify desired t1 image with tag: #DWIQC_T1w (note the lack of trailing integers).\nSee documentation for further details: <docs_link>')
+                    sys.exit()
+                keeper_scans[run]['t1w'] = scan['id']
+
+    # populate fmap scans
+    for scan in all_usable_scans:
+        for scan_label in scan_labels:
+            is_match = match(scan['note'], conf['dwiqc'][scan_label]['tag'])
+            if is_match:
+                run = is_match.group('run').lstrip('_')
+                keeper_scans[run][scan_label] = scan['id']
+
+    return keeper_scans
+
+def find_main_diffusion_scans(keeper_scans, all_usable_scans, conf):
+    '''
+    find all the diffusion scans in the session
+    '''
+    for scan in all_usable_scans:
+        verify_dwi_label(conf)
+        is_match = match(scan['note'], conf['dwiqc']['dwi_main']['tag'])
+        if is_match:
+            run = is_match.group('run').lstrip('_')
+            keeper_scans[run]['dwi_main'] = scan['id']
+
+    if not diffusion_exist(keeper_scans):
+        logger.error('No diffusion scans found. Please check your tagging convention and your download-config.yaml file.')
+        sys.exit()
+
+    else:
+        logger.debug('marking dwi_main scan label as complete')
+        return keeper_scans, True
+
+
+def contains_just_dwiqc_t1w(scan_note):
+    '''
+    Check if '#DWIQC_T1w' exists as a standalone tag in the given scan note.
+    Returns False if followed by additional characters (e.g. '_001').
+    Case insensitive.
+    '''
+    pattern = r'(?i)#DWIQC_T1w(?!\w)'
+    return bool(re.search(pattern, scan_note))
+
+def get_usable_scans(auth, label, project):
+    with yaxil.session(auth) as ses:
+            all_scans = []
+            for scan in ses.scans(label=label, project=project):
+                if scan['quality'] == 'unusable':
+                    logger.warning(f"scan {scan['ID']} is unusable and will not be downloaded")
+                    continue
+                else:
+                    all_scans.append(scan)
+    return all_scans
+
+
 def run_xnattagger(args):
 
     """
@@ -94,26 +180,25 @@ def run_xnattagger(args):
     logging.info('Running xnattagger...')
 
     with open(args.tagger_config) as fo:
-        filters = yaml.load(fo, Loader=yaml.SafeLoader)
+        filters = yaml.load(fo, Loader=yaml.SafeLoader)['xnat-tagger']
 
-    tagger_dwi = Tagger(args.xnat_alias, filters, 'dwi', args.label)
+    tagger_dwi = Tagger(args.xnat_alias, filters, 'dwi', args.label, append_tag_digits=True)
     tagger_dwi.generate_updates()
     tagger_dwi.apply_updates()
 
-    tagger_t1 = Tagger(args.xnat_alias, filters, 't1', args.label)
+    tagger_t1 = Tagger(args.xnat_alias, filters, 't1', args.label, append_tag_digits=False)
     tagger_t1.generate_updates()
     tagger_t1.apply_updates()
 
-def get_scans(conf):
-
-    """
+def get_scan_types(conf):
+    '''
     Helper function to dynamically create a list of all the modalities/scans listed in the config file
-    
-    """
+    '''
     
     scan_types = [scan_type for scan_type in conf['dwiqc']]
 
     return scan_types
+
 
 def download_scan(args, auth, run, scan, config_label, input_config, verbose=False):
 

--- a/dwiqc/cli/tandem.py
+++ b/dwiqc/cli/tandem.py
@@ -1,21 +1,21 @@
 import os
 import re
 import sys
+import pdb
 import json
 import yaml
 import yaxil
 import logging
+import yaxil.bids
 import argparse as ap
 import subprocess as sp
 import collections as col
-from xnattagger import Tagger
-from bids import BIDSLayout
-import dwiqc.cli.get as get
-import dwiqc.cli.process as process
 import collections as col
-import yaxil.bids
+import dwiqc.cli.get as get
+from bids import BIDSLayout
 from xnattagger import Tagger
-import xnattagger.config as config 
+import xnattagger.config as config
+import dwiqc.cli.process as process
 
 
 logger = logging.getLogger(__name__)
@@ -50,12 +50,10 @@ def do(args):
     scan_labels = get_scan_types(conf) ### get a list of the scan types/labels
 
     # query dwi and T1w scans from XNAT
-    scans_to_download = find_scans_to_download(scan_labels, conf, auth, args.label, args.project)
+    scans_to_download, subject_label = find_scans_to_download(scan_labels, conf, auth, args.label, args.project)
 
     logger.info('downloading the following scans:')
     logger.info(json.dumps(scans_to_download, indent=2))
-
-    #subject_label = scan['subject_label']
 
     scan_labels = get_scan_types(conf)
 
@@ -93,7 +91,7 @@ def find_scans_to_download(scan_labels, conf, auth, label, project):
 
     keeper_scans = populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num_diffusion_scans=len(keeper_scans))
 
-    return keeper_scans
+    return keeper_scans, all_usable_scans[0]['subject_label']
 
 def populate_keeper_scans(keeper_scans, all_usable_scans, scan_labels, conf, num_diffusion_scans):
     '''

--- a/dwiqc/cli/tandem.py
+++ b/dwiqc/cli/tandem.py
@@ -53,9 +53,9 @@ def do(args):
     scans_to_download = find_scans_to_download(scan_labels, conf, auth, args.label, args.project)
 
     logger.info('downloading the following scans:')
-    logger.info(json.dumps(scans, indent=2))
+    logger.info(json.dumps(scans_to_download, indent=2))
 
-    subject_label = scan['subject_label']
+    #subject_label = scan['subject_label']
 
     scan_labels = get_scan_types(conf)
 
@@ -148,6 +148,18 @@ def find_main_diffusion_scans(keeper_scans, all_usable_scans, conf):
         logger.debug('marking dwi_main scan label as complete')
         return keeper_scans, True
 
+def verify_dwi_label(conf):
+    try:
+        dwi_label = conf['dwiqc']['dwi_main']['tag']
+    except:
+        logger.error('please specify a "dwi_main" label in your download-config.yaml file')
+        sys.exit()
+
+def diffusion_exist(keeper_scans):
+    for value in keeper_scans.values():
+        if 'dwi_main' in value:
+            return True
+    return False
 
 def contains_just_dwiqc_t1w(scan_note):
     '''

--- a/dwiqc/xnat/__init__.py
+++ b/dwiqc/xnat/__init__.py
@@ -215,7 +215,7 @@ class Report:
         qcdir = os.path.join(self.dirs['qsiprep'], 'qsiprep_output', 'qsiprep', 'EDDY', f'{no_prefix_sub}_{self.ses}.qc')
         for filename in os.listdir(qcdir):
             fullfile = os.path.join(qcdir, filename)
-            match = re.match('avg_b(\d+).png', filename)
+            match = re.match(r'avg_b(\d+).png', filename)
             if not match:
                 continue
             shells.append(int(match.group(1)))

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 requires = [
-    'yaxil==0.9.14',
+    'yaxil',
     'pyaml',
     'xnattagger>=0.9.0',
     'PyBIDS',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 requires = [
     'yaxil==0.9.14',
     'pyaml',
-    'xnattagger>=0.6.6',
+    'xnattagger>=0.9.0',
     'PyBIDS',
     'executors==0.6a1',
     'selfie',


### PR DESCRIPTION
Release Notes
===========

Changes to how get and tandem mode download data from XNAT
-----------------------------------------------------------------
1. The usability label gets checked for each scan before being downloaded. If it is marked “unusable” it will not be downloaded.
2. Dwiqc builds a data structure populated with scans to be downloaded. The data structure gets built based on the number of “main” diffusion scans in a given session. For example, if there are two “main” diffusion scans, dwiqc expects there to be accompanying field maps for each of them, one set labeled as run 001 and the other as run 002. There can also be T1w scans labeled 001 and 002, however it is not required. A user with one T1w scan that should be used for analysis of all “main” diffusion scans should place the tag #DWIQC_T1w in the note field of that T1 on XNAT. 

Changes to xnattagger
-----------------------

1. Users running xnattagger will need to nest their tagger config files under ‘xnat-tagger’ as shown below:

```yaml
xnat-tagger:
    dwi:
        - series_description: ABCD_dMRI_lowSR
          image_type: [ORIGINAL, PRIMARY, DIFFUSION, NONE, ND, MOSAIC]
          tag: '#DWI_MAIN_001'
        - series_description: UKbioDiff_ABCDseq_ABCDdvs
          image_type: [ORIGINAL, PRIMARY, DIFFUSION, NONE, ND, MOSAIC]
          tag: '#DWI_MAIN_001'
    dwi_PA:
        - series_description: ABCD_dMRI_DistortionMap_PA
          image_type: [ORIGINAL, PRIMARY, DIFFUSION, NONE, ND]
          tag: '#DWI_FMAP_PA_001'
        - series_description: UKbioDiff_ABCDseq_DistMap_PA
          image_type: [ORIGINAL, PRIMARY, DIFFUSION, NONE, ND]
          tag: '#DWI_FMAP_PA_001'
    dwi_AP:
        - series_description: ABCD_dMRI_DistortionMap_AP
          image_type: [ORIGINAL, PRIMARY, DIFFUSION, NONE, ND]
          tag: '#DWI_FMAP_AP_001'
        - series_description: UKbioDiff_ABCDseq_DistMap_AP
          image_type: [ORIGINAL, PRIMARY, DIFFUSION, NONE, ND]
          tag: '#DWI_FMAP_AP_001'
    t1w:
        - series_description: PBN_T1w_MPR_vNav
          secondary_image_type: [ORIGINAL, PRIMARY, M, ND, NORM]
          tag: '#DWIQC_T1w'
```
Updates to dependencies
--------------------------
Use newest versions of yaxil and xnattagger